### PR TITLE
Make equals (=) button span two rows

### DIFF
--- a/index.css
+++ b/index.css
@@ -127,5 +127,7 @@ body {
   grid-column-end: 2;
 }
 
-
-
+.equals {
+  grid-column: 4;
+  grid-row: 5 / span 2;
+}

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <button data-value="0" class="child zero" aria-label="Number 0">0</button>
             <button data-value="DE" class="child DE" aria-label="Delete">DE</button>
             <button data-value="." class="child" aria-label="Decimal point">.</button>
-            <button data-value="=" data-operator  class="child operator" aria-label="Equal sign">=</button>
+            <button data-value="=" data-operator  class="child operator equals" aria-label="Equal sign">=</button>
             <button data-value="history" class="history-btn" aria-label="History button">history</button>
             <button data-value="(" data-operator  class="child operator" aria-label="Opening parenthesis">(</button>
             <button data-value=")" data-operator  class="child operator" aria-label="Closing parenthesis">)</button>


### PR DESCRIPTION
![Screenshot from 2024-01-05 20-36-56](https://github.com/josueJURE/calculator/assets/33418880/1f817870-5211-4b8c-acfb-c47d5a3a6624)

Matches calculator UI conventions, here's an example of another calculator app:
![Screenshot from 2024-01-05 20-53-08](https://github.com/josueJURE/calculator/assets/33418880/06add99f-4724-46e6-8971-dad92aa75daf)
